### PR TITLE
Upgrade highlight.js new API

### DIFF
--- a/utils/markdown.ts
+++ b/utils/markdown.ts
@@ -4,11 +4,11 @@ import { highlight, highlightAuto } from 'highlight.js';
 export function markdownToHtml(md: string, baseUrl?: string) {
   const html = marked(md, {
     baseUrl,
-    highlight: (code, lang) => {
-      if (!lang) {
+    highlight: (code, language) => {
+      if (!language) {
         return highlightAuto(code).value;
       }
-      return highlight(lang, code).value;
+      return highlight(code, { language }).value;
     },
   });
   return html;


### PR DESCRIPTION
> Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
> Deprecated as of 10.7.0. Please use highlight(code, options) instead.

https://github.com/highlightjs/highlight.js/issues/2277

