### PR TITLE
Enable browserslist

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,8 @@ const nextConfig = {
     formats: ['image/avif', 'image/webp'],
   },
   experimental: {
+    browsersListForSwc: true,
+    legacyBrowsers: false,
     images: {
 			allowFutureImage: true,
       remotePatterns: [{

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "prettier": "prettier \"./**/*.ts\" \"./**/*.tsx\" \"./styles/*.css\" --write",
     "git-pre-commit": "yarn prettier && git add -A"
   },
+  "browserslist": [
+    "supports es6-module-dynamic-import",
+    "not dead"
+  ],
   "dependencies": {
     "@octokit/rest": "18.12.0",
     "gray-matter": "4.0.3",


### PR DESCRIPTION
Drop support for older browsers using `browserslist`

- main.js dropped from 32.6KB to 26.4KB
