### PR TITLE
Use octokit type directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@octokit/types": "7.5.1",
     "@types/marked": "4.0.7",
     "@types/node": "16",
     "@types/react": "18.0.21",

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,4 +1,4 @@
-import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
+import type { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import { Octokit } from '@octokit/rest';
 import { existsSync, promises } from 'fs';
 const { readFile, writeFile } = promises;

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,3 +1,4 @@
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import { Octokit } from '@octokit/rest';
 import { existsSync, promises } from 'fs';
 const { readFile, writeFile } = promises;
@@ -6,81 +7,9 @@ if (!process.env.GH_TOKEN) {
 }
 const octokit = new Octokit({ auth: process.env.GH_TOKEN });
 
-export interface Repo {
-  id: number;
-  node_id: string;
-  name: string;
-  full_name: string;
-  private: boolean;
-  owner: any;
-  html_url: string;
-  description: string | null;
-  fork: boolean;
-  url: string;
-  forks_url: string;
-  keys_url: string;
-  collaborators_url: string;
-  teams_url: string;
-  hooks_url: string;
-  issue_events_url: string;
-  events_url: string;
-  assignees_url: string;
-  branches_url: string;
-  tags_url: string;
-  blobs_url: string;
-  git_tags_url: string;
-  git_refs_url: string;
-  trees_url: string;
-  statuses_url: string;
-  languages_url: string;
-  stargazers_url: string;
-  contributors_url: string;
-  subscribers_url: string;
-  subscription_url: string;
-  commits_url: string;
-  git_commits_url: string;
-  comments_url: string;
-  issue_comment_url: string;
-  contents_url: string;
-  compare_url: string;
-  merges_url: string;
-  archive_url: string;
-  downloads_url: string;
-  issues_url: string;
-  pulls_url: string;
-  milestones_url: string;
-  notifications_url: string;
-  labels_url: string;
-  releases_url: string;
-  deployments_url: string;
-  created_at: string | null;
-  updated_at: string | null;
-  pushed_at: string | null;
-  git_url: string | null;
-  ssh_url: string | null;
-  clone_url: string | null;
-  svn_url: string | null;
-  homepage: string | null;
-  size: number;
-  stargazers_count: number;
-  watchers_count: number;
-  language: string | null;
-  has_issues: boolean;
-  has_projects: boolean;
-  has_downloads: boolean;
-  has_wiki: boolean;
-  has_pages: boolean;
-  forks_count: number;
-  mirror_url: any;
-  archived: boolean;
-  disabled: boolean;
-  open_issues_count: number;
-  license: any;
-  forks: number;
-  open_issues: number;
-  watchers: number;
-  default_branch: string;
-}
+export type Repo = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.repos.listForAuthenticatedUser
+>[number];
 
 const validGitHubProjectKeys = [
   'name',
@@ -171,7 +100,7 @@ export async function getProjects(): Promise<GitHubProject[]> {
     Object.keys(r)
       .filter(k => !validGitHubProjectKeys.includes(k))
       .forEach(k => {
-        const project = r as any;
+        const project = r as Record<string, unknown>;
         delete project[k];
       });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,6 +202,11 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-13.0.1.tgz#f655810f0dc0547b771526fea171acffbc7bd4a8"
   integrity sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg==
 
+"@octokit/openapi-types@^13.11.0":
+  version "13.13.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-13.13.1.tgz#a783bacb1817c9f61a2a0c3f81ea22ad62340fdf"
+  integrity sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ==
+
 "@octokit/openapi-types@^9.5.0":
   version "9.7.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-9.7.0.tgz#9897cdefd629cd88af67b8dbe2e5fb19c63426b2"
@@ -257,6 +262,13 @@
     "@octokit/plugin-paginate-rest" "^4.0.0"
     "@octokit/plugin-request-log" "^1.0.4"
     "@octokit/plugin-rest-endpoint-methods" "^6.0.0"
+
+"@octokit/types@7.5.1":
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-7.5.1.tgz#4e8b182933c17e1f41cc25d44757dbdb7bd76c1b"
+  integrity sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==
+  dependencies:
+    "@octokit/openapi-types" "^13.11.0"
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
   version "6.25.0"


### PR DESCRIPTION
Also found you can use the type directly here to make things much more maintainable and avoid a bunch of `any`s

### Testing
- `yarn build` passed type-checking