### PR TITLE
fix(blog): mention `COREPACK_ENABLE_STRICT`

### DIFF
--- a/_posts/2022-08-07-corepack.md
+++ b/_posts/2022-08-07-corepack.md
@@ -77,4 +77,4 @@ Corepack ensures that you, your collaborators, your CI, your [deployment platfor
 
 Corepack is considered [experimental status](https://nodejs.org/api/corepack.html#corepack) but there is a discussion about [going stable](https://github.com/nodejs/corepack/issues/104) in the future.
 
-The biggest caveat I've found today is that Corepack can sometimes be too strict and cause [Usage Error: This project is configured to use pkgmgr](https://github.com/nodejs/corepack/issues/157), however skip this strict check this by setting `COREPACK_ENABLE_STRICT=0` which is a fine workaround.
+The biggest caveat I've found today is that Corepack can sometimes be too strict and cause [Usage Error: This project is configured to use pkgmgr](https://github.com/nodejs/corepack/issues/157). However, you can skip this strict check by setting the `COREPACK_ENABLE_STRICT=0` environment variable.

--- a/_posts/2022-08-07-corepack.md
+++ b/_posts/2022-08-07-corepack.md
@@ -77,4 +77,4 @@ Corepack ensures that you, your collaborators, your CI, your [deployment platfor
 
 Corepack is considered [experimental status](https://nodejs.org/api/corepack.html#corepack) but there is a discussion about [going stable](https://github.com/nodejs/corepack/issues/104) in the future.
 
-The biggest caveat I've found today is that Corepack can sometimes be too strict and cause [Usage Error: This project is configured to use pkgmgr](https://github.com/nodejs/corepack/issues/157).
+The biggest caveat I've found today is that Corepack can sometimes be too strict and cause [Usage Error: This project is configured to use pkgmgr](https://github.com/nodejs/corepack/issues/157), however skip this strict check this by setting `COREPACK_ENABLE_STRICT=0` which is a fine workaround.


### PR DESCRIPTION
This mentions how to use `COREPACK_ENABLE_STRICT=0`