### PR TITLE
fix: restrict `qualities` to [50, 75]

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: import('next').NextConfig = {
   },
   images: {
     formats: ['image/avif', 'image/webp'],
+    qualities: [50, 75],
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
We don't need 1 through 100 since default is 75